### PR TITLE
Fix dead link

### DIFF
--- a/docs_src/src/usage.md
+++ b/docs_src/src/usage.md
@@ -41,7 +41,7 @@ wish for anyone to be able to broadcast a signal, the owner of the Semaphore
 contract (either a Client contract or externally owned account) must first
 invoke `setPermissioning(false)`.
 
-See [SemaphoreClient.sol](./contracts/sol/SemaphoreClient.sol) for an example.
+See [SemaphoreClient.sol](https://github.com/appliedzkp/semaphore/blob/master/contracts/sol/SemaphoreClient.sol) for an example.
 
 ## Insert identities
 


### PR DESCRIPTION
The link was resolved to `https://appliedzkp.github.io/semaphore/contracts/sol/SemaphoreClient.sol`, which doesn't work.